### PR TITLE
Include Chessbook as a production app using rspc

### DIFF
--- a/content/docs/rspc/index.mdx
+++ b/content/docs/rspc/index.mdx
@@ -36,6 +36,7 @@ rspc is a typesafe router for Rust which allows you to build end-to-end type saf
       - [CrabNebula Cloud](https://crabnebula.dev/cloud)
       - [Macrograph](https://macrograph.app)
       - [Twidge](https://github.com/twidgeapp/twidge)
+      - [Chessbook](https://chessbook.com)
 
   </Accordion>
 


### PR DESCRIPTION
I've been using rspc for [Chessbook](https://chessbook.com) for about 6 months now and I've loved it, total game-changer.

Feel free to close this, just figure showing as many sites using it in production as possible is good for the project. 

Chessbook is not open source fwiw, don't know if that's an unspoken requirement for the list.